### PR TITLE
fw: fix public signing key fingerprint search

### DIFF
--- a/org.sofproject.fw/src/org/sofproject/fw/keys/SimpleFwKeyResolver.java
+++ b/org.sofproject.fw/src/org/sofproject/fw/keys/SimpleFwKeyResolver.java
@@ -29,7 +29,6 @@
 package org.sofproject.fw.keys;
 
 import java.util.Arrays;
-import java.util.List;
 
 public class SimpleFwKeyResolver {
 
@@ -73,8 +72,8 @@ public class SimpleFwKeyResolver {
 		return instance;
 	}
 
-	public static String searchModulusName(List<byte[]> modulus) {
-		byte[] mod10 = Arrays.copyOf(modulus.get(0), 10);
+	public static String searchModulusName(byte[] modulus) {
+		byte[] mod10 = Arrays.copyOf(modulus, 10);
 		for (KeyEntry key : getInstance().keys) {
 			if (Arrays.equals(key.keyBegin, mod10))
 				return key.keyName;
@@ -82,10 +81,10 @@ public class SimpleFwKeyResolver {
 		return getFrontHex(modulus);
 	}
 
-	private static String getFrontHex(List<byte[]> modulus) {
+	private static String getFrontHex(byte[] modulus) {
 		int i = 0;
 		StringBuffer sb = new StringBuffer("[");
-		for (byte b : modulus.get(0)) {
+		for (byte b : modulus) {
 			sb.append(String.format("%02x ", b));
 			if (++i == 10) {
 				sb.append("...");

--- a/org.sofproject.fw/src/org/sofproject/fw/model/FwBinGraph.java
+++ b/org.sofproject.fw/src/org/sofproject/fw/model/FwBinGraph.java
@@ -138,7 +138,7 @@ public class FwBinGraph {
 		binBlock.setAttribute(FwBinBlock.AG_GRAPH, "version", hdr.getChildItem("ver").getValueString());
 		binBlock.setAttribute(FwBinBlock.AG_GRAPH, "date", hdr.getChildItem("date").getValueString());
 		binBlock.setAttribute(FwBinBlock.AG_GRAPH, "signing key",
-				SimpleFwKeyResolver.searchModulusName((List<byte[]>) hdr.getChildValue("modulus")));
+				SimpleFwKeyResolver.searchModulusName((byte[]) hdr.getChildValue("modulus")));
 	}
 
 	private static void addFwVersionAttribs(FwBinBlock binBlock, BinStructFwVersion fwVer) {


### PR DESCRIPTION
FW binary graph failed to open, caused by bad cast left
while simplifying binary byte array binding.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>