### PR TITLE
alsa-topo: fix bytes display in data element

### DIFF
--- a/org.sofproject.alsa.topo/src/org/sofproject/alsa/topo/conf/ConfBytes.java
+++ b/org.sofproject.alsa.topo/src/org/sofproject/alsa/topo/conf/ConfBytes.java
@@ -68,6 +68,9 @@ public class ConfBytes extends ConfAttribute {
 
 	@Override
 	public String getStringValue() {
+		if (value == null) {
+			return "(null)";
+		}
 		StringBuilder sb = new StringBuilder();
 		int i = 0;
 		for (byte b : value) {


### PR DESCRIPTION
When SectionData had only tuples and no bytes defined
there was null ptr exception when calling getStringValue()
from places like the Outline view.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>